### PR TITLE
Fix issue with requests received before srv_conf section is loaded

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -8,7 +8,8 @@ services:
         volumes:
             - ./docker/nginx.conf:/etc/nginx/nginx.conf
             - logs:/var/log/nginx
- 
+    echo:
+        image: jmalloc/echo-server:0.3.3
     test_e2e:
         build:
             context: .
@@ -20,7 +21,7 @@ services:
             - logs:/var/log/nginx
         depends_on:
             - nginx
-
+            - echo
     test:
         build:
             context: .

--- a/docker/Dockerfile.e2e
+++ b/docker/Dockerfile.e2e
@@ -1,8 +1,8 @@
-FROM rust:alpine3.13
+FROM rust:1.63.0-alpine3.16
 
 USER root
 
-RUN apk add --no-cache musl-dev && cargo install websocat
+RUN apk add --no-cache musl-dev openssl-dev pkgconfig && cargo install websocat
 
 COPY ./docker/test_e2e.sh /usr/local/bin/test_e2e
 RUN chmod +x /usr/local/bin/test_e2e

--- a/docker/nginx.conf
+++ b/docker/nginx.conf
@@ -14,7 +14,7 @@ http {
     location / {
       proxy_buffering off;
       proxy_request_buffering off;
-      proxy_pass https://echo.websocket.org;
+      proxy_pass http://echo:8080/;
       proxy_ssl_server_name on;
       proxy_http_version 1.1;
       proxy_set_header Connection "upgrade";

--- a/docker/test_e2e.sh
+++ b/docker/test_e2e.sh
@@ -6,13 +6,12 @@ set -exo pipefail
 
 cat <<EOF > /tmp/ws-expected.log
 OPEN
-CLIENT->SERVER: 1311 (websocket)
-SERVER->CLIENT: 1311 (websocket)
+SERVER->CLIENT: 30 (websocket)
+CLIENT->SERVER: 7 (websocket)
+SERVER->CLIENT: 7 (websocket)
 CLOSE
 EOF
 
-echo "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum. Sed ut perspiciatis unde omnis iste natus error sit voluptatem accusantium doloremque laudantium, totam rem aperiam, eaque ipsa quae ab illo inventore veritatis et quasi architecto beatae vitae dicta sunt explicabo. Nemo enim ipsam voluptatem quia voluptas sit aspernatur aut odit aut fugit, sed quia consequuntur magni dolores eos qui ratione voluptatem sequi nesciunt. Neque porro quisquam est, qui dolorem ipsum quia dolor sit amet, consectetur, adipisci velit, sed quia non numquam eius modi tempora incidunt ut labore et dolore magnam aliquam quaerat voluptatem. Ut enim ad minima veniam, quis nostrum exercitationem ullam corporis suscipit laboriosam, nisi ut aliquid ex ea commodi consequatur? Quis autem vel eum iure reprehenderit qui in ea voluptate velit esse quam nihil molestiae consequatur, vel illum qui dolorem eum fugiat quo voluptas nulla pariatur?" \
-| tr -d \\n \
-| websocat --text -1 ws://${ENDPOINT}
+echo "asdasd" | websocat --text ws://${ENDPOINT}
 
 diff ${LOG_FILE_PATH} /tmp/ws-expected.log

--- a/src/ngx_http_websocket_stat_module.c
+++ b/src/ngx_http_websocket_stat_module.c
@@ -182,13 +182,21 @@ ssize_t
 my_recv(ngx_connection_t *c, u_char *buf, size_t size)
 {
     ngx_http_request_t *r = c->data;
-    ngx_http_websocket_srv_conf_t *srvcf = ngx_http_get_module_srv_conf(r, ngx_http_websocket_stat_module);
-    ngx_http_websocket_stat_request_ctx *request_ctx = ngx_http_get_module_ctx(r, ngx_http_websocket_stat_module);
+
 
     int n = orig_recv(c, buf, size);
     if (n <= 0) {
         return n;
     }
+    
+    if (r->srv_conf == NULL || r->ctx == NULL) {
+        // Related to the bug when we calculated request right after reload and server config yet to load so it was NULL and caused crash.
+        // Part r->ctx == NULL allows to prevents same problem in case module_ctx would be unloaded for some reason.
+        return n;
+    }
+
+    ngx_http_websocket_srv_conf_t *srvcf = ngx_http_get_module_srv_conf(r, ngx_http_websocket_stat_module);
+    ngx_http_websocket_stat_request_ctx *request_ctx = ngx_http_get_module_ctx(r, ngx_http_websocket_stat_module);
 
     ssize_t sz = n;
     template_ctx_s template_ctx;

--- a/src/ngx_http_websocket_stat_module.c
+++ b/src/ngx_http_websocket_stat_module.c
@@ -188,11 +188,11 @@ my_recv(ngx_connection_t *c, u_char *buf, size_t size)
     if (n <= 0) {
         return n;
     }
-    
+    ngx_log_error(NGX_LOG_ERR, ngx_cycle->log, 0, "USERMETRICS Websocket package processing");
     if (r->srv_conf == NULL || r->ctx == NULL) {
         // Related to the bug when we calculated request right after reload and server config yet to load so it was NULL and caused crash.
         // Part r->ctx == NULL allows to prevents same problem in case module_ctx would be unloaded for some reason.
-        ngx_log_error(NGX_LOG_ERR, ngx_cycle->log, 0, "Websocket package was processed without billing due to issue CORE-4874.");
+        ngx_log_error(NGX_LOG_ERR, ngx_cycle->log, 0, "USERMETRICS Websocket package was processed without billing due to issue CORE-4874.");
         return n;
     }
 

--- a/src/ngx_http_websocket_stat_module.c
+++ b/src/ngx_http_websocket_stat_module.c
@@ -192,6 +192,7 @@ my_recv(ngx_connection_t *c, u_char *buf, size_t size)
     if (r->srv_conf == NULL || r->ctx == NULL) {
         // Related to the bug when we calculated request right after reload and server config yet to load so it was NULL and caused crash.
         // Part r->ctx == NULL allows to prevents same problem in case module_ctx would be unloaded for some reason.
+        ngx_log_error(NGX_LOG_NOTICE, ngx_cycle->log, 0, "Websocket package was processed without billing due to issue CORE-4874.");
         return n;
     }
 

--- a/src/ngx_http_websocket_stat_module.c
+++ b/src/ngx_http_websocket_stat_module.c
@@ -192,7 +192,7 @@ my_recv(ngx_connection_t *c, u_char *buf, size_t size)
     if (r->srv_conf == NULL || r->ctx == NULL) {
         // Related to the bug when we calculated request right after reload and server config yet to load so it was NULL and caused crash.
         // Part r->ctx == NULL allows to prevents same problem in case module_ctx would be unloaded for some reason.
-        ngx_log_error(NGX_LOG_NOTICE, ngx_cycle->log, 0, "Websocket package was processed without billing due to issue CORE-4874.");
+        ngx_log_error(NGX_LOG_ERR, ngx_cycle->log, 0, "Websocket package was processed without billing due to issue CORE-4874.");
         return n;
     }
 

--- a/src/ngx_http_websocket_stat_module.c
+++ b/src/ngx_http_websocket_stat_module.c
@@ -185,9 +185,6 @@ my_recv(ngx_connection_t *c, u_char *buf, size_t size)
 
 
     int n = orig_recv(c, buf, size);
-    if (n <= 0) {
-        return n;
-    }
     ngx_log_error(NGX_LOG_ERR, ngx_cycle->log, 0, "USERMETRICS Websocket package processing");
     if (r->srv_conf == NULL || r->ctx == NULL) {
         // Related to the bug when we calculated request right after reload and server config yet to load so it was NULL and caused crash.
@@ -195,7 +192,9 @@ my_recv(ngx_connection_t *c, u_char *buf, size_t size)
         ngx_log_error(NGX_LOG_ERR, ngx_cycle->log, 0, "USERMETRICS Websocket package was processed without billing due to issue CORE-4874.");
         return n;
     }
-
+    if (n <= 0) {
+        return n;
+    }
     ngx_http_websocket_srv_conf_t *srvcf = ngx_http_get_module_srv_conf(r, ngx_http_websocket_stat_module);
     ngx_http_websocket_stat_request_ctx *request_ctx = ngx_http_get_module_ctx(r, ngx_http_websocket_stat_module);
 


### PR DESCRIPTION
Some requests (from my observations their size was always zero) come before srv_conf loads and it causes segfault.
I added not null checks to ensure we don't run into this issue again and moved return statement in case size==0 up so we don't execute extra code in this case.