### PR TITLE
SEC-130: bump Ingress-NGINX to v1.11.5

### DIFF
--- a/docker/Dockerfile.nginx
+++ b/docker/Dockerfile.nginx
@@ -1,4 +1,4 @@
-FROM registry.k8s.io/ingress-nginx/controller:v1.11.2 as builder
+FROM registry.k8s.io/ingress-nginx/controller:v1.11.5 as builder
 
 USER root
 
@@ -14,5 +14,5 @@ RUN cd ./chainstack && \
     --add-dynamic-module=../ngx_http_websocket_stat_module && \
     make modules
 
-FROM registry.k8s.io/ingress-nginx/controller:v1.11.2
+FROM registry.k8s.io/ingress-nginx/controller:v1.11.5
 COPY --from=builder /tmp/chainstack/objs/ngx_http_websocket_stat_module.so /etc/nginx/modules/


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated container configuration to use a newer, stable version of the ingress controller for enhanced reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->